### PR TITLE
Github action workflow: runs-on ubuntu 22.04

### DIFF
--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -76,7 +76,7 @@ on:
 jobs:
   build:
     name: Build MT7621 u-boot
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
        fail-fast: False
 


### PR DESCRIPTION
Running on `ubuntu-latest` gives out error, as `python2-dev` packages is dropped in ubuntu 24.04.

Changing it to `ubuntu-22.04` makes the workflow works again.